### PR TITLE
Correct version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CVE-2017-1000486
-Primefaces &lt;= 5.2.21, 5.3.8 or 6.0 - Remote Code Execution Exploit
+Primefaces &lt; 5.2.21, 5.3.8 or 6.0 - Remote Code Execution Exploit
 
 To install the requirements execute:
 


### PR DESCRIPTION
The vuln was [fixed](https://github.com/primefaces/primefaces/issues/1152) in 5.2.21, 5.3.8 and 6.0. See also the [blog post](https://web.archive.org/web/20191111063636/https://www.primefaces.org/primefaces-el-injection-update/).